### PR TITLE
Prevent traefik whoami command from replacing /bin/busybox

### DIFF
--- a/image/Containerfile
+++ b/image/Containerfile
@@ -1,6 +1,6 @@
 FROM docker.io/alpine:latest
 
-COPY --from=docker.io/traefik/whoami:latest /whoami /usr/bin/whoami
+COPY --from=docker.io/traefik/whoami:latest /whoami /usr/bin/traefik-whoami
 RUN apk add --no-cache curl
 ENV WHOAMI_PORT_NUMBER=8080
-CMD ["whoami"]
+CMD ["traefik-whoami"]


### PR DESCRIPTION
Our base image is `docker.io/alpine`, which includes a `/usr/bin/whoami`
command that is a symlink to `/bin/busybox`. Our `Containerfile` included
the following directive:

    COPY --from=docker.io/traefik/whoami:latest /whoami /usr/bin/whoami

When building with `podman`, this successfully replaces `/usr/bin/whoami`.
When building with `docker` (which is what is used on Github), the `COPY`
directive follows the symlink and so replaces `/bin/busybox`.

Since almost all binaries on the `alpine` image are symlinks to
`/bin/busybox`, this made all commands, including `/bin/sh`, run the
Traefik `whoami` command.

The resolution is to copy the new binary to a different name
(`/usr/bin/traefik-whoami`) and update `CMD` to use the new name.
